### PR TITLE
Link to bundled OpenSSL if requested

### DIFF
--- a/main/curl/curl-bundled_openssl.patch
+++ b/main/curl/curl-bundled_openssl.patch
@@ -1,0 +1,28 @@
+--- misc/curl-7.72.0/configure	2020-08-17 00:34:29.000000000 +0200
++++ misc/build/curl-7.72.0/configure	2022-05-05 19:03:39.766880970 +0200
+@@ -23617,14 +23617,14 @@
+       { $as_echo "$as_me:${as_lineno-$LINENO}: PKG_CONFIG_LIBDIR will be set to \"$OPENSSL_PCDIR\"" >&5
+ $as_echo "$as_me: PKG_CONFIG_LIBDIR will be set to \"$OPENSSL_PCDIR\"" >&6;}
+       PKGTEST="yes"
+-    elif test ! -f "$PREFIX_OPENSSL/include/openssl/ssl.h"; then
++    elif test ! -f "$PREFIX_OPENSSL/inc/external/openssl/ssl.h"; then
+       as_fn_error $? "$PREFIX_OPENSSL is a bad --with-ssl prefix!" "$LINENO" 5
+     fi
+ 
+             LIB_OPENSSL="$PREFIX_OPENSSL/lib$libsuff"
+     if test "$PREFIX_OPENSSL" != "/usr" ; then
+       SSL_LDFLAGS="-L$LIB_OPENSSL"
+-      SSL_CPPFLAGS="-I$PREFIX_OPENSSL/include"
++      SSL_CPPFLAGS="-I$PREFIX_OPENSSL/inc/external"
+     fi
+     SSL_CPPFLAGS="$SSL_CPPFLAGS -I$PREFIX_OPENSSL/include/openssl"
+     ;;
+@@ -23841,7 +23841,7 @@
+      LDFLAGS="$CLEANLDFLAGS -L$LIB_OPENSSL"
+      if test "$PKGCONFIG" = "no" ; then
+        # only set this if pkg-config wasn't used
+-       CPPFLAGS="$CLEANCPPFLAGS -I$PREFIX_OPENSSL/include/openssl -I$PREFIX_OPENSSL/include"
++       CPPFLAGS="$CLEANCPPFLAGS -I$PREFIX_OPENSSL/inc/external/openssl -I$PREFIX_OPENSSL/inc/external"
+      fi
+      # Linking previously failed, try extra paths from --with-ssl or pkg-config.
+      # Use a different function name to avoid reusing the earlier cached result.

--- a/main/curl/makefile.mk
+++ b/main/curl/makefile.mk
@@ -55,10 +55,17 @@ curl_CFLAGS+:=$(ARCH_FLAGS)
 curl_LDFLAGS+:=$(ARCH_FLAGS)
 .ENDIF
 
+.IF "$(SYSTEM_OPENSSL)"=="YES"
+ssl_param=--with-ssl
+.ELSE
+ssl_param=--with-ssl=$(OUTDIR)
+PATCH_FILES+= curl-bundled_openssl.patch
+.ENDIF
+
 CONFIGURE_DIR=.$/
 #relative to CONFIGURE_DIR
 CONFIGURE_ACTION=.$/configure
-CONFIGURE_FLAGS= --with-ssl --without-libidn --enable-ftp --enable-ipv6 --enable-http --disable-gopher --disable-file --disable-ldap --disable-telnet --disable-dict --disable-static CPPFLAGS="$(curl_CFLAGS)"  LDFLAGS="$(curl_LDFLAGS)"
+CONFIGURE_FLAGS= $(ssl_param) --without-libidn --enable-ftp --enable-ipv6 --enable-http --disable-gopher --disable-file --disable-ldap --disable-telnet --disable-dict --disable-static CPPFLAGS="$(curl_CFLAGS)"  LDFLAGS="$(curl_LDFLAGS)"
 
 BUILD_DIR=$(CONFIGURE_DIR)$/lib
 BUILD_ACTION=$(GNUMAKE)


### PR DESCRIPTION
"Bundled" OpenSSL (and other bundled libraries) are installed into `$OUTDIR` following a non-standard path structure. For this reason, the configure script must be patched.

This edit is only for Unix builds. Apparently, Windows builds are already doing the right thing.